### PR TITLE
Use `unic_langid::LanguageIdentifier` for language IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "serde_derive",
  "syntect",
  "toml",
+ "unic-langid",
  "utils",
 ]
 
@@ -1156,6 +1157,7 @@ dependencies = [
  "tempfile",
  "tera",
  "toml",
+ "unic-langid",
  "utils",
 ]
 
@@ -1839,6 +1841,7 @@ dependencies = [
  "library",
  "site",
  "tempfile",
+ "unic-langid",
 ]
 
 [[package]]
@@ -2096,6 +2099,7 @@ dependencies = [
  "errors",
  "lazy_static",
  "library",
+ "unic-langid",
 ]
 
 [[package]]
@@ -2205,6 +2209,7 @@ dependencies = [
  "tempfile",
  "templates",
  "tera",
+ "unic-langid",
  "utils",
 ]
 
@@ -2419,6 +2424,7 @@ dependencies = [
  "svg_metadata",
  "tera",
  "toml",
+ "unic-langid",
  "url",
  "utils",
 ]
@@ -2651,6 +2657,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a4a8eeaf0494862c1404c95ec2f4c33a2acff5076f64314b465e3ddae1b934d"
 dependencies = [
+ "serde",
  "tinystr",
 ]
 

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -13,6 +13,7 @@ chrono = "0.4"
 globset = "0.4"
 lazy_static = "1"
 syntect = "4.1"
+unic-langid = { version = "0.9", features = ["serde","macros"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }

--- a/components/config/src/config/languages.rs
+++ b/components/config/src/config/languages.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
 use serde_derive::{Deserialize, Serialize};
+use unic_langid::LanguageIdentifier;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Language {
     /// The language code
-    pub code: String,
+    pub code: LanguageIdentifier,
     /// Whether to generate a feed for that language, defaults to `false`
     pub feed: bool,
     /// Whether to generate search index for that language, defaults to `false`
@@ -15,7 +16,7 @@ pub struct Language {
 
 impl Default for Language {
     fn default() -> Self {
-        Language { code: String::new(), feed: false, search: false }
+        Language { code: LanguageIdentifier::default(), feed: false, search: false }
     }
 }
 

--- a/components/config/src/config/slugify.rs
+++ b/components/config/src/config/slugify.rs
@@ -2,7 +2,6 @@ use serde_derive::{Deserialize, Serialize};
 
 use utils::slugs::SlugifyStrategy;
 
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Slugify {

--- a/components/config/src/config/taxonomies.rs
+++ b/components/config/src/config/taxonomies.rs
@@ -1,5 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 
+use unic_langid::LanguageIdentifier;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Taxonomy {
@@ -13,7 +15,7 @@ pub struct Taxonomy {
     pub feed: bool,
     /// The language for that taxonomy, only used in multilingual sites.
     /// Defaults to the config `default_language` if not set
-    pub lang: String,
+    pub lang: LanguageIdentifier,
 }
 
 impl Taxonomy {
@@ -41,7 +43,7 @@ impl Default for Taxonomy {
             paginate_by: None,
             paginate_path: None,
             feed: false,
-            lang: String::new(),
+            lang: LanguageIdentifier::default(),
         }
     }
 }

--- a/components/config/src/lib.rs
+++ b/components/config/src/lib.rs
@@ -1,7 +1,9 @@
 mod config;
 pub mod highlighting;
 mod theme;
-pub use crate::config::{Config, languages::Language, link_checker::LinkChecker, taxonomies::Taxonomy};
+pub use crate::config::{
+    languages::Language, link_checker::LinkChecker, taxonomies::Taxonomy, Config,
+};
 
 use std::path::Path;
 

--- a/components/library/Cargo.toml
+++ b/components/library/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1"
 serde_derive = "1"
 regex = "1"
 lazy_static = "1"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 front_matter = { path = "../front_matter" }
 config = { path = "../config" }

--- a/components/library/src/content/page.rs
+++ b/components/library/src/content/page.rs
@@ -6,6 +6,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use slotmap::DefaultKey;
 use tera::{Context as TeraContext, Tera};
+use unic_langid::LanguageIdentifier;
 
 use crate::library::Library;
 use config::Config;
@@ -75,7 +76,7 @@ pub struct Page {
     pub reading_time: Option<usize>,
     /// The language of that page. Equal to the default lang if the user doesn't setup `languages` in config.
     /// Corresponds to the lang in the {slug}.{lang}.md file scheme
-    pub lang: String,
+    pub lang: LanguageIdentifier,
     /// Contains all the translated version of that page
     pub translations: Vec<DefaultKey>,
     /// Contains the internal links that have an anchor: we can only check the anchor
@@ -111,7 +112,7 @@ impl Page {
             toc: vec![],
             word_count: None,
             reading_time: None,
-            lang: String::new(),
+            lang: LanguageIdentifier::default(),
             translations: Vec::new(),
             internal_links_with_anchors: Vec::new(),
             external_links: Vec::new(),
@@ -357,7 +358,7 @@ impl Default for Page {
             toc: vec![],
             word_count: None,
             reading_time: None,
-            lang: String::new(),
+            lang: LanguageIdentifier::default(),
             translations: Vec::new(),
             internal_links_with_anchors: Vec::new(),
             external_links: Vec::new(),
@@ -375,6 +376,7 @@ mod tests {
     use globset::{Glob, GlobSetBuilder};
     use tempfile::tempdir;
     use tera::Tera;
+    use unic_langid::langid;
 
     use super::Page;
     use config::{Config, Language};
@@ -770,7 +772,7 @@ Hello world
     #[test]
     fn can_specify_language_in_filename() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 +++
@@ -779,7 +781,7 @@ Bonjour le monde"#
         let res = Page::parse(Path::new("hello.fr.md"), &content, &config, &PathBuf::new());
         assert!(res.is_ok());
         let page = res.unwrap();
-        assert_eq!(page.lang, "fr".to_string());
+        assert_eq!(page.lang, langid!("fr"));
         assert_eq!(page.slug, "hello");
         assert_eq!(page.permalink, "http://a-website.com/fr/hello/");
     }
@@ -787,7 +789,7 @@ Bonjour le monde"#
     #[test]
     fn can_specify_language_in_filename_with_date() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 +++
@@ -798,7 +800,7 @@ Bonjour le monde"#
         assert!(res.is_ok());
         let page = res.unwrap();
         assert_eq!(page.meta.date, Some("2018-10-08".to_string()));
-        assert_eq!(page.lang, "fr".to_string());
+        assert_eq!(page.lang, langid!("fr"));
         assert_eq!(page.slug, "hello");
         assert_eq!(page.permalink, "http://a-website.com/fr/hello/");
     }
@@ -806,7 +808,7 @@ Bonjour le monde"#
     #[test]
     fn i18n_frontmatter_path_overrides_default_permalink() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 path = "bonjour"
@@ -816,7 +818,7 @@ Bonjour le monde"#
         let res = Page::parse(Path::new("hello.fr.md"), &content, &config, &PathBuf::new());
         assert!(res.is_ok());
         let page = res.unwrap();
-        assert_eq!(page.lang, "fr".to_string());
+        assert_eq!(page.lang, langid!("fr"));
         assert_eq!(page.slug, "hello");
         assert_eq!(page.permalink, "http://a-website.com/bonjour/");
     }

--- a/components/library/src/content/section.rs
+++ b/components/library/src/content/section.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use slotmap::DefaultKey;
 use tera::{Context as TeraContext, Tera};
+use unic_langid::LanguageIdentifier;
 
 use config::Config;
 use errors::{Error, Result};
@@ -54,7 +55,7 @@ pub struct Section {
     pub reading_time: Option<usize>,
     /// The language of that section. Equal to the default lang if the user doesn't setup `languages` in config.
     /// Corresponds to the lang in the _index.{lang}.md file scheme
-    pub lang: String,
+    pub lang: LanguageIdentifier,
     /// Contains all the translated version of that section
     pub translations: Vec<DefaultKey>,
     /// Contains the internal links that have an anchor: we can only check the anchor
@@ -91,7 +92,7 @@ impl Section {
             toc: vec![],
             word_count: None,
             reading_time: None,
-            lang: String::new(),
+            lang: LanguageIdentifier::default(),
             translations: Vec::new(),
             internal_links_with_anchors: Vec::new(),
             external_links: Vec::new(),
@@ -274,7 +275,7 @@ impl Default for Section {
             toc: vec![],
             reading_time: None,
             word_count: None,
-            lang: String::new(),
+            lang: LanguageIdentifier::default(),
             translations: Vec::new(),
             internal_links_with_anchors: Vec::new(),
             external_links: Vec::new(),
@@ -290,6 +291,7 @@ mod tests {
 
     use globset::{Glob, GlobSetBuilder};
     use tempfile::tempdir;
+    use unic_langid::langid;
 
     use super::Section;
     use config::{Config, Language};
@@ -350,7 +352,7 @@ mod tests {
     #[test]
     fn can_specify_language_in_filename() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 +++
@@ -364,7 +366,7 @@ Bonjour le monde"#
         );
         assert!(res.is_ok());
         let section = res.unwrap();
-        assert_eq!(section.lang, "fr".to_string());
+        assert_eq!(section.lang, langid!("fr"));
         assert_eq!(section.permalink, "http://a-website.com/fr/hello/nested/");
     }
 
@@ -372,7 +374,7 @@ Bonjour le monde"#
     #[test]
     fn can_make_links_to_translated_sections_without_double_trailing_slash() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 +++
@@ -382,14 +384,14 @@ Bonjour le monde"#
             Section::parse(Path::new("content/_index.fr.md"), &content, &config, &PathBuf::new());
         assert!(res.is_ok());
         let section = res.unwrap();
-        assert_eq!(section.lang, "fr".to_string());
+        assert_eq!(section.lang, langid!("fr"));
         assert_eq!(section.permalink, "http://a-website.com/fr/");
     }
 
     #[test]
     fn can_make_links_to_translated_subsections_with_trailing_slash() {
         let mut config = Config::default();
-        config.languages.push(Language { code: String::from("fr"), feed: false, search: false });
+        config.languages.push(Language { code: langid!("fr"), feed: false, search: false });
         let content = r#"
 +++
 +++
@@ -403,7 +405,7 @@ Bonjour le monde"#
         );
         assert!(res.is_ok());
         let section = res.unwrap();
-        assert_eq!(section.lang, "fr".to_string());
+        assert_eq!(section.lang, langid!("fr"));
         assert_eq!(section.permalink, "http://a-website.com/fr/subcontent/");
     }
 }

--- a/components/library/src/content/ser.rs
+++ b/components/library/src/content/ser.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use serde_derive::Serialize;
 use tera::{Map, Value};
+use unic_langid::LanguageIdentifier;
 
 use crate::content::{Page, Section};
 use crate::library::Library;
@@ -11,7 +12,7 @@ use rendering::Heading;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TranslatedContent<'a> {
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
     permalink: &'a str,
     title: &'a Option<String>,
     /// The path to the markdown file; useful for retrieving the full page through
@@ -78,7 +79,7 @@ pub struct SerializingPage<'a> {
     reading_time: Option<usize>,
     assets: &'a [String],
     draft: bool,
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
     lighter: Option<Box<SerializingPage<'a>>>,
     heavier: Option<Box<SerializingPage<'a>>>,
     earlier: Option<Box<SerializingPage<'a>>>,
@@ -222,7 +223,7 @@ pub struct SerializingSection<'a> {
     toc: &'a [Heading],
     word_count: Option<usize>,
     reading_time: Option<usize>,
-    lang: &'a str,
+    lang: &'a LanguageIdentifier,
     assets: &'a [String],
     pages: Vec<SerializingPage<'a>>,
     subsections: Vec<&'a str>,

--- a/components/library/src/taxonomies/mod.rs
+++ b/components/library/src/taxonomies/mod.rs
@@ -233,6 +233,8 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    use unic_langid::langid;
+
     use crate::content::Page;
     use crate::library::Library;
     use config::{Config, Language, Taxonomy as TaxonomyConfig};
@@ -458,7 +460,7 @@ mod tests {
     #[test]
     fn can_make_taxonomies_in_multiple_languages() {
         let mut config = Config::default();
-        config.languages.push(Language { feed: false, code: "fr".to_string(), search: false });
+        config.languages.push(Language { feed: false, code: langid!("fr"), search: false });
         let mut library = Library::new(2, 0, true);
 
         config.taxonomies = vec![
@@ -474,12 +476,12 @@ mod tests {
             },
             TaxonomyConfig {
                 name: "auteurs".to_string(),
-                lang: "fr".to_string(),
+                lang: langid!("fr"),
                 ..TaxonomyConfig::default()
             },
             TaxonomyConfig {
                 name: "tags".to_string(),
-                lang: "fr".to_string(),
+                lang: langid!("fr"),
                 ..TaxonomyConfig::default()
             },
         ];
@@ -501,7 +503,7 @@ mod tests {
         library.insert_page(page2);
 
         let mut page3 = Page::default();
-        page3.lang = "fr".to_string();
+        page3.lang = langid!("fr");
         let mut taxo_page3 = HashMap::new();
         taxo_page3.insert("tags".to_string(), vec!["rust".to_string()]);
         taxo_page3.insert("auteurs".to_string(), vec!["Vincent Prouillet".to_string()]);
@@ -568,21 +570,17 @@ mod tests {
     fn can_make_utf8_taxonomies() {
         let mut config = Config::default();
         config.slugify.taxonomies = SlugifyStrategy::Safe;
-        config.languages.push(Language {
-            feed: false,
-            code: "fr".to_string(),
-            ..Language::default()
-        });
+        config.languages.push(Language { feed: false, code: langid!("fr"), ..Language::default() });
         let mut library = Library::new(2, 0, true);
 
         config.taxonomies = vec![TaxonomyConfig {
             name: "catégories".to_string(),
-            lang: "fr".to_string(),
+            lang: langid!("fr"),
             ..TaxonomyConfig::default()
         }];
 
         let mut page = Page::default();
-        page.lang = "fr".to_string();
+        page.lang = langid!("fr");
         let mut taxo_page = HashMap::new();
         taxo_page.insert("catégories".to_string(), vec!["Écologie".to_string()]);
         page.meta.taxonomies = taxo_page;
@@ -601,11 +599,7 @@ mod tests {
     fn can_make_slugified_taxonomies_in_multiple_languages() {
         let mut config = Config::default();
         config.slugify.taxonomies = SlugifyStrategy::On;
-        config.languages.push(Language {
-            feed: false,
-            code: "fr".to_string(),
-            ..Language::default()
-        });
+        config.languages.push(Language { feed: false, code: langid!("fr"), ..Language::default() });
         let mut library = Library::new(2, 0, true);
 
         config.taxonomies = vec![
@@ -621,12 +615,12 @@ mod tests {
             },
             TaxonomyConfig {
                 name: "auteurs".to_string(),
-                lang: "fr".to_string(),
+                lang: langid!("fr"),
                 ..TaxonomyConfig::default()
             },
             TaxonomyConfig {
                 name: "tags".to_string(),
-                lang: "fr".to_string(),
+                lang: langid!("fr"),
                 ..TaxonomyConfig::default()
             },
         ];
@@ -648,7 +642,7 @@ mod tests {
         library.insert_page(page2);
 
         let mut page3 = Page::default();
-        page3.lang = "fr".to_string();
+        page3.lang = langid!("fr");
         let mut taxo_page3 = HashMap::new();
         taxo_page3.insert("tags".to_string(), vec!["rust".to_string()]);
         taxo_page3.insert("auteurs".to_string(), vec!["Vincent Prouillet".to_string()]);

--- a/components/rebuild/Cargo.toml
+++ b/components/rebuild/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 include = ["src/lib.rs"]
 
 [dependencies]
+unic-langid = "0.9"
+
 errors = { path = "../errors" }
 front_matter = { path = "../front_matter" }
 library = { path = "../library" }

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 elasticlunr-rs = {version = "2", default-features = false, features = ["da", "de", "du", "es", "fi", "fr", "it", "pt", "ro", "ru", "sv", "tr"] }
 ammonia = "3"
 lazy_static = "1"
+unic-langid = "0.9"
 
 errors = { path = "../errors" }
 library = { path = "../library" }

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use elasticlunr::{Index, Language};
 use lazy_static::lazy_static;
+use unic_langid::LanguageIdentifier;
 
 use errors::{bail, Result};
 use library::{Library, Section};
@@ -29,8 +30,8 @@ lazy_static! {
 /// the language given
 /// Errors if the language given is not available in Elasticlunr
 /// TODO: is making `in_search_index` apply to subsections of a `false` section useful?
-pub fn build_index(lang: &str, library: &Library) -> Result<String> {
-    let language = match Language::from_code(lang) {
+pub fn build_index(lang: &LanguageIdentifier, library: &Library) -> Result<String> {
+    let language = match Language::from_code(lang.language.as_str()) {
         Some(l) => l,
         None => {
             bail!("Tried to build search index for language {} which is not supported", lang);
@@ -40,7 +41,7 @@ pub fn build_index(lang: &str, library: &Library) -> Result<String> {
     let mut index = Index::with_language(language, &["title", "body"]);
 
     for section in library.sections_values() {
-        if section.lang == lang {
+        if &section.lang == lang {
             add_section_to_index(&mut index, section, library);
         }
     }

--- a/components/site/Cargo.toml
+++ b/components/site/Cargo.toml
@@ -12,6 +12,7 @@ rayon = "1"
 serde = "1"
 serde_derive = "1"
 sass-rs = "0.2"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 config = { path = "../config" }

--- a/components/templates/Cargo.toml
+++ b/components/templates/Cargo.toml
@@ -15,6 +15,7 @@ image = "0.23"
 serde_json = "1.0"
 sha2 = "0.9"
 url = "2"
+unic-langid = { version = "0.9", features = ["serde", "macros"] }
 
 errors = { path = "../errors" }
 utils = { path = "../utils" }


### PR DESCRIPTION
This change was proposed by XAMPPRocky in #1040.